### PR TITLE
Update code to validate python bin versions

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -113,6 +113,7 @@ COPY ./docker/fonts /home/node/.fonts
 ENV TCD_BIN_DIR=/usr/local/bin
 ENV TCD_FFMPEG_PATH=/usr/bin/ffmpeg
 ENV TCD_BIN_PATH_PYTHON=/usr/bin/python
+ENV TCD_BIN_PATH_PYTHON3=/usr/bin/python3
 ENV TCD_MEDIAINFO_PATH=/usr/bin/mediainfo
 ENV TCD_NODE_PATH=/usr/local/bin/node
 ENV TCD_DOCKER=1

--- a/server/src/Core/Config.ts
+++ b/server/src/Core/Config.ts
@@ -75,8 +75,8 @@ export class Config {
         }
 
         // return from env if set
-        if (process.env[`TCD_${key.toUpperCase()}`] !== undefined) {
-            const val: string | undefined = process.env[`TCD_${key.toUpperCase()}`];
+        if (this.hasEnvVar(key)) {
+            const val: string | undefined = this.envVarValue(key);
             if (val === undefined) {
                 return <T>defaultValue; // should not happen
             }
@@ -117,7 +117,7 @@ export class Config {
             console.warn(chalk.red(`Setting '${key}' does not exist.`));
         }
 
-        if (process.env[`TCD_${key.toUpperCase().replaceAll(".", "_")}`] !== undefined) {
+        if (this.hasEnvVar(key)) {
             return true;
         }
 
@@ -645,6 +645,16 @@ export class Config {
 
     get dateFormat() {
         return this.cfg("date_format", "yyyy-MM-dd"); // if you're crazy enough to not use ISO8601
+    }
+
+    hasEnvVar(key: keyof typeof settingsFields): boolean
+    {
+        return process.env[`TCD_${key.toUpperCase().replaceAll(".", "_")}`] !== undefined;
+    }
+
+    envVarValue(key: keyof typeof settingsFields): string | undefined
+    {
+        return process.env[`TCD_${key.toUpperCase().replaceAll(".", "_")}`];
     }
 
 }

--- a/server/src/Core/Helper.ts
+++ b/server/src/Core/Helper.ts
@@ -53,10 +53,10 @@ export class Helper {
         return false;
     }
 
-    // public static path_python3(): string | false {
-    //     if (Config.getInstance().hasValue("bin_path.python3")) return Config.getInstance().cfg<string>("bin_path.python3");
-    //     return false;
-    // }
+    public static path_python3(): string | false {
+        if (Config.getInstance().hasValue("bin_path.python3")) return Config.getInstance().cfg<string>("bin_path.python3");
+        return false;
+    }
 
     // very bad
     public static path_ffprobe(): string | false {

--- a/server/src/Helpers/Software.ts
+++ b/server/src/Helpers/Software.ts
@@ -19,7 +19,7 @@ export function DVRBinaries(): Record<string, BinaryDef> {
         mediainfo: { binary: Helper.path_mediainfo(), version_args: ["--Version"], version_regex: /v(\d+\.\d+)/m },
         twitchdownloader: { binary: Helper.path_twitchdownloader(), version_args: ["--version", "2>&1"], version_regex: /TwitchDownloaderCLI (\d+\.\d+\.\d+)/m },
         python: { binary: Helper.path_python(), version_args: ["--version"], version_regex: /Python ([\d.]+)/m },
-        // python3: { binary: Helper.path_python3(), version_args: ["--version"], version_regex: /Python ([\d.]+)/m },
+        python3: { binary: Helper.path_python3(), version_args: ["--version"], version_regex: /Python ([\d.]+)/m },
         node: { binary: Helper.path_node(), version_args: ["--version"], version_regex: /v([\d.]+)/m },
         // php: { binary: "php", version_args: ["-v"], version_regex: /PHP Version ([\d.]+)/m }, // deprecated
     };


### PR DESCRIPTION
Python versions weren't being properly validated and displayed in the app.

- Updated the code to make validation work
- Update Config class with methods to read/check env vars
- Add python3 env var to dockerfile

![image](https://user-images.githubusercontent.com/26017611/226466885-7844ee4a-6386-4a45-984f-99ca57940449.png)
