### PR TITLE
Fix pipenv detection by updating dockerfile to install pipenv

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update && apt-get install -y \
 
 # pip packages
 COPY ./requirements.txt /tmp/requirements.txt
-RUN pip install -r /tmp/requirements.txt \
+RUN pip install pipenv && pip install -r /tmp/requirements.txt \
     && rm /tmp/requirements.txt \
     && pip cache purge
 


### PR DESCRIPTION
By adding `pip3 install --user pipenv` to Dockerfile, the UI is now able to detect `pipenv` version properly.

I noticed this after seeing the following error msg in the logs:

`helper <ERROR> pipenv binary not found at: /usr/local/bin/pipenv`