### PR TITLE
Fix YouTube playlist insert

### DIFF
--- a/server/src/Exporters/YouTube.ts
+++ b/server/src/Exporters/YouTube.ts
@@ -412,7 +412,7 @@ export class YouTubeExporter extends BaseExporter {
                 part: ["snippet"],
                 requestBody: {
                     snippet: {
-                        playlistId: playlist_id,
+                        playlistId: this.playlist_id,
                         resourceId: {
                             kind: "youtube#video",
                             videoId: video_id,


### PR DESCRIPTION
Using the Docker `develop` image, I noticed that the YouTube playlist insert API call failed with the message `Playlist id not specified`.
It's fixed after adding a 'this.' before the playlist_id variable.

```
2024-01-04T19:42:52.886Z | YouTubeExporter.export <success> Video uploaded: wuM-TsF7XXX
2024-01-04T19:42:52.887Z | YouTubeExporter.addToPlaylist <info> Adding wuM-TsF7XXX to playlist...
2024-01-04T19:42:52.887Z | YouTubeExporter.addToPlaylist <info> Found playlist PLvNNyUh4Ovo0Zk9PLjUsFMPYoSAcXXXX for channel XYZ
2024-01-04T19:42:53.223Z | YouTubeExporter.addToPlaylist <error> Could not add video to playlist: Playlist id not specified.
2024-01-04T19:42:53.223Z | YouTubeExporter.export <error> Could not add video to playlist: Playlist id not specified.
2024-01-04T19:42:53.224Z | automator.onEndDownload <error> Export error: Playlist id not specified.
```