### PR TITLE
Added field for additional args for streamlink in settings

### DIFF
--- a/common/ServerConfig.ts
+++ b/common/ServerConfig.ts
@@ -372,7 +372,11 @@ export const settingsFields = createSettingsFields({
         default: false,
         help: "Capture to saved_vods if any of the capture methods fail",
     },
-
+    "capture.streamlink-args": {
+        group: "Capture",
+        text: "Additional Streamlink Args",
+        type: "string",
+    },
     "capture.twitch-api-header": {
         group: "Capture",
         text: "Twitch API header",

--- a/server/src/Core/Providers/Twitch/TwitchAutomator.ts
+++ b/server/src/Core/Providers/Twitch/TwitchAutomator.ts
@@ -683,6 +683,15 @@ export class TwitchAutomator extends BaseAutomator {
         // disable reruns
         cmd.push("--twitch-disable-reruns");
 
+        // Add additional args
+        if (Config.getInstance().hasValue("capture.streamlink-args")) {
+            cmd.push(
+                ...Config.getInstance()
+                    .cfg<string>("capture.streamlink-args")
+                    .split(" ")
+            );
+        }
+
         // one custom api header
         if (Config.getInstance().hasValue("capture.twitch-api-header")) {
             cmd.push(

--- a/server/src/Core/Providers/Twitch/TwitchVOD.ts
+++ b/server/src/Core/Providers/Twitch/TwitchVOD.ts
@@ -460,6 +460,16 @@ export class TwitchVOD extends BaseVOD {
                 cmd.push("--loglevel", "info");
             }
 
+            // Add additional args
+            if (Config.getInstance().hasValue("capture.streamlink-args")) {
+                cmd.push(
+                    ...Config.getInstance()
+                        .cfg<string>("capture.streamlink-args")
+                        .split(" ")
+                );
+            }
+            
+
             log(
                 LOGLEVEL.INFO,
                 "tw.vod.downloadVideo",
@@ -722,6 +732,16 @@ export class TwitchVOD extends BaseVOD {
             } else if (Config.getInstance().cfg("app_verbose", false)) {
                 cmd.push("--loglevel", "info");
             }
+
+            // Add additional args
+            if (Config.getInstance().hasValue("capture.streamlink-args")) {
+                cmd.push(
+                    ...Config.getInstance()
+                        .cfg<string>("capture.streamlink-args")
+                        .split(" ")
+                );
+            }
+
 
             log(
                 LOGLEVEL.INFO,


### PR DESCRIPTION
Added a field to setting to allow users to pass additional argumants to streamlink. 

This is usefull for passing flags that are currently not supported along with future flags that me be added by stream link without the need to update LiveStreamDVR