### PR TITLE
Client.vue fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
-#what  i will try to do in this fork:
+# what  i will try to do in this fork:
+
 -delete the capture if it is still exists and download the vod to fix the cut segments in the captured vod
 
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,7 @@
+#what  i will try to do in this fork:
+-delete the capture if it is still exists and download the vod to fix the cut segments in the captured vod
+
+
 # LiveStreamDVR
 
 [![Check Server](https://github.com/MrBrax/LiveStreamDVR/actions/workflows/check-server.yml/badge.svg)](https://github.com/MrBrax/LiveStreamDVR/actions/workflows/check-server.yml) [![Check Client](https://github.com/MrBrax/LiveStreamDVR/actions/workflows/check-client.yml/badge.svg)](https://github.com/MrBrax/LiveStreamDVR/actions/workflows/check-client.yml) [![Publish Docker image](https://github.com/MrBrax/LiveStreamDVR/actions/workflows/docker-publish.yml/badge.svg)](https://github.com/MrBrax/LiveStreamDVR/actions/workflows/docker-publish.yml)

--- a/client-vue/src/components/vod/VodItemBookmarks.vue
+++ b/client-vue/src/components/vod/VodItemBookmarks.vue
@@ -124,6 +124,7 @@ function playerLink(bookmark: VODBookmark): RouteLocationRaw {
         },
     };
 }
+
 </script>
 
 <style lang="scss" scoped>

--- a/client-vue/src/components/vod/VodItemBookmarks.vue
+++ b/client-vue/src/components/vod/VodItemBookmarks.vue
@@ -49,6 +49,8 @@ import { onMounted, ref } from "vue";
 import { useI18n } from "vue-i18n";
 import type { VODTypes } from "@/twitchautomator";
 import type { VODBookmark } from "@common/Bookmark";
+import type { RouteLocationRaw } from "vue-router";
+
 
 const props = defineProps({
     vod: {
@@ -107,8 +109,11 @@ function doDeleteBookmark(i: number) {
         });
 }
 
-function playerLink(bookmark: VODBookmark) {
-    if (!props.vod) return;
+function playerLink(bookmark: VODBookmark): RouteLocationRaw {
+    if (!props.vod) {
+        // return a fallback route if props.vod is not defined
+        return "/";
+    }
     return {
         name: "Editor",
         params: {
@@ -118,7 +123,6 @@ function playerLink(bookmark: VODBookmark) {
             start: bookmark.offset,
         },
     };
-    // return `/player/${props.vod.uuid}?bookmark=${bookmark.offset}`;
 }
 </script>
 


### PR DESCRIPTION
closes: https://github.com/MrBrax/LiveStreamDVR/issues/511

the error occured because `playerLink `can return `undefined`, and Vue Router's `to` property strictly expects a `RouteLocationRaw `type, which does not include `undefined`.